### PR TITLE
Adds embedded timecode metadata support

### DIFF
--- a/ffmpegutil/ffmpeg.go
+++ b/ffmpegutil/ffmpeg.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strconv"
 	"ubvremux/ubv"
+	"fmt"
 )
 
 func MuxVideoOnly(partition *ubv.UbvPartition, h264File string, mp4File string) {

--- a/ffmpegutil/ffmpeg.go
+++ b/ffmpegutil/ffmpeg.go
@@ -56,7 +56,24 @@ func MuxAudioAndVideo(partition *ubv.UbvPartition, h264File string, aacFile stri
 		videoTrack.Rate = 1
 	}
 
-	cmd := exec.Command(getFfmpegCommand(), "-i", h264File, "-itsoffset", strconv.FormatFloat(audioDelaySec, 'f', -1, 32), "-i", aacFile, "-map", "0:v", "-map", "1:a", "-c", "copy", "-r", strconv.Itoa(videoTrack.Rate), "-y", "-loglevel", "warning", mp4File)
+	var timecode string
+	// calculate timecode ( HH:MM:SS.FRAME ) from seconds and nanoseconds
+	timecode = videoTrack.StartTimecode.Format("15:04:05") + "." + fmt.Sprintf("%02.0f", ((float32(videoTrack.StartTimecode.Nanosecond()) / float32(1000000000.0) * float32(videoTrack.Rate)) + 1) )
+	log.Println("Timecode: ", timecode)
+	log.Printf("Date/Time: %s", videoTrack.StartTimecode)
+
+	cmd := exec.Command(getFfmpegCommand(), 
+		"-i", h264File, 
+		"-itsoffset", strconv.FormatFloat(audioDelaySec, 'f', -1, 32), 
+		"-i", aacFile, 
+		"-map", "0:v", 
+		"-map", "1:a", 
+		"-c", "copy", 
+		"-r", strconv.Itoa(videoTrack.Rate), 
+		"-timecode", timecode,
+		"-y", 
+		"-loglevel", "warning", 
+		mp4File)
 
 	runFFmpeg(cmd)
 }

--- a/ffmpegutil/ffmpeg.go
+++ b/ffmpegutil/ffmpeg.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"strconv"
 	"ubvremux/ubv"
-	"fmt"
 )
 
 func MuxVideoOnly(partition *ubv.UbvPartition, h264File string, mp4File string) {
@@ -57,12 +56,6 @@ func MuxAudioAndVideo(partition *ubv.UbvPartition, h264File string, aacFile stri
 		videoTrack.Rate = 1
 	}
 
-	var timecode string
-	// calculate timecode ( HH:MM:SS.FRAME ) from seconds and nanoseconds
-	timecode = videoTrack.StartTimecode.Format("15:04:05") + "." + fmt.Sprintf("%02.0f", ((float32(videoTrack.StartTimecode.Nanosecond()) / float32(1000000000.0) * float32(videoTrack.Rate)) + 1) )
-	log.Println("Timecode: ", timecode)
-	log.Printf("Date/Time: %s", videoTrack.StartTimecode)
-
 	cmd := exec.Command(getFfmpegCommand(), 
 		"-i", h264File, 
 		"-itsoffset", strconv.FormatFloat(audioDelaySec, 'f', -1, 32), 
@@ -71,7 +64,7 @@ func MuxAudioAndVideo(partition *ubv.UbvPartition, h264File string, aacFile stri
 		"-map", "1:a", 
 		"-c", "copy", 
 		"-r", strconv.Itoa(videoTrack.Rate), 
-		"-timecode", timecode,
+		"-timecode", ubv.GenerateTimecode(videoTrack.StartTimecode, videoTrack.Rate),
 		"-y", 
 		"-loglevel", "warning", 
 		mp4File)

--- a/ubv/ubvfile.go
+++ b/ubv/ubvfile.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strconv"
 	"time"
+	"fmt"
 )
 
 const (
@@ -152,4 +153,25 @@ func guessVideoRate(durations [32]int) int {
 	}
 
 	return mostFrequent
+}
+
+/**
+ * Generates a timecode string from a StartTimecode object and framerate.
+ * The timecode is set as the wall clock time (so a clip starting at 03:45 pm and 13 seconds will have a timestamp of 03:45:13)
+ * Additionally, the nanosecond time value is rounded to the nearest frame index based on the framerate,
+ * so a 13.50000 second time is frame 16 on a 30 fps clip (frames are indexed from 1 onwards). 
+ * So the clip will have a full timestamp of 03:34:13.16
+ *
+ * @param startTimecode The StartTimecode object to generate a timecode string from
+ * @param framerate The framerate of the video
+ * @return The timecode string
+ */
+ func GenerateTimecode(startTimecode time.Time, framerate int) string {
+	
+	var timecode string
+	// calculate timecode ( HH:MM:SS.FF ) from seconds and nanoseconds for frame part
+	timecode = startTimecode.Format("15:04:05") + "." + fmt.Sprintf("%02.0f", ((float32(startTimecode.Nanosecond()) / float32(1000000000.0) * float32(framerate)) + 1) )
+	// log.Println("Timecode: ", timecode)
+	// log.Printf("Date/Time: %s", videoTrack.StartTimecode)
+	return timecode
 }

--- a/ubvfile_test.go
+++ b/ubvfile_test.go
@@ -7,6 +7,14 @@ import (
 	"ubvremux/ubv"
 )
 
+func TestGenerateTimecode(t *testing.T) {                                           
+	timecode := ubv.GenerateTimecode(time.Date(2023, time.Month(5), 16, 11, 58, 26, 500000000, time.UTC), 30)
+	log.Printf("Timecode Generated")
+	if timecode != "11:58:26.16" {
+		t.Errorf("Timecode generated is incorrect, got: %s, want: %s.", timecode, "11:58:26.16")
+	}
+}
+
 func TestCopyFrames(t *testing.T) {
 	ubvFile := "samples/FCECDA1F0A63_0_rotating_1597425468956.ubv"
 


### PR DESCRIPTION
This update adds timecode support to the generated .mp4 files

The timecode is calculated from the timestamp recorded in the .ubv, and is set as the wall clock time (so a clip starting at 03:45 pm and 13 seconds will have a timestamp of `03:45:13`.

Additionally, the nanosecond time value is rounded to the nearest frame index based on the framerate, so a 13.50000 second time is frame 16 on a 30 fps clip (frames are indexed from 1 onwards). So the clip will have a full timestamp of `03:34:13.16`