### PR TITLE
Added timecode generation to video-only remuxing

### DIFF
--- a/ffmpegutil/ffmpeg.go
+++ b/ffmpegutil/ffmpeg.go
@@ -21,7 +21,20 @@ func MuxVideoOnly(partition *ubv.UbvPartition, h264File string, mp4File string) 
 		videoTrack.Rate = 1
 	}
 
-	cmd := exec.Command(getFfmpegCommand(), "-i", h264File, "-c", "copy", "-r", strconv.Itoa(videoTrack.Rate), "-y", "-loglevel", "warning", mp4File)
+	var timecode string
+	// calculate timecode from seconds and nanoseconds
+	timecode = videoTrack.StartTimecode.Format("15:04:05") + "." + fmt.Sprintf("%02.0f", ((float32(videoTrack.StartTimecode.Nanosecond()) / float32(1000000000.0) * float32(videoTrack.Rate)) + 1) )
+	log.Println("Timecode: ", timecode)
+	log.Printf("Date/Time: %s", videoTrack.StartTimecode)
+
+	cmd := exec.Command(getFfmpegCommand(), 
+	"-i", h264File,
+	"-c", "copy",
+	"-r", strconv.Itoa(videoTrack.Rate),
+	"-timecode", timecode,
+	"-y",
+	"-loglevel", "warning",
+	mp4File)
 
 	runFFmpeg(cmd)
 }


### PR DESCRIPTION
In PR #30 I forgot to add the timecode bits to video-only remuxing, so cameras without audio were not getting the timecode on them.